### PR TITLE
Use icon as icon for files

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,11 @@
       "id": "cherri",
       "aliases": ["Cherri", "cherri"],
       "extensions": [".cherri"],
-      "configuration": "./language-configuration.json"
+      "configuration": "./language-configuration.json",
+      "icon": {
+         "light": "./cherri_icon.png",
+         "dark": "./cherri_icon.png"
+       }
     }],
     "grammars": [{
       "language": "cherri",


### PR DESCRIPTION
Use the `cherri_icon.png` as the icon for Cherri files.